### PR TITLE
specify what file to use for ssh

### DIFF
--- a/tasks/borg-client.yml
+++ b/tasks/borg-client.yml
@@ -22,6 +22,7 @@
     content: |
       Host {{ item.fqdn }}
         StrictHostKeyChecking no
+        IdentityFile {{ borgbackup_ssh_key }}
         {% if item.port is defined %}
         Port {{ item.port }}
         {% endif %}


### PR DESCRIPTION
Some ssh configs don't try by default all identity files, thus specify explicitly for the backup host what identity file to use


Signed-off-by: Jochen Maes <jochen@sejo-it.be>