### PR TITLE
Allow undefined borgbackup_servers and borgbackup_management groups.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,23 @@
 ---
+# Due to inverse logic behaviour when searching for an item in an undefined list.
+- set_fact:
+    borgbackup_servers_group: "{{ groups.borgbackup_servers | default([]) }} "
+    borgbackup_management_group: "{{ groups.borgbackup_management | default([]) }}"
+
 - include_tasks: install.yml
   when: >
     borgbackup_required == True or
-    inventory_hostname in groups.borgbackup_servers
+    inventory_hostname in borgbackup_servers_group
 
 - include_tasks: borg-server.yml
-  when: inventory_hostname in groups.borgbackup_servers
+  when: inventory_hostname in borgbackup_servers_group
 
 - include_tasks: borg-client.yml
   when: >
     borgbackup_required == True and
-    inventory_hostname not in groups.borgbackup_servers
+    inventory_hostname not in borgbackup_servers_group
 
 - include_tasks: management.yml
   when: >
-    inventory_hostname in groups.borgbackup_management and
-    inventory_hostname not in groups.borgbackup_servers
+    inventory_hostname in borgbackup_management_group and
+    inventory_hostname not in borgbackup_servers_group


### PR DESCRIPTION
When there is no group defined, the conditional to find a value in a list is broken and passes as true.

This PR sets facts to ensure that undefined group lists are regarded as empty.

Without this change, the hosts groups would need to be defined as empty groups:
```yaml
[borgbackup_servers]
# Empty...

[borgbackup_management]
# Empty...
```