### PR TITLE
prune.sh fixes

### DIFF
--- a/templates/borg-backup.sh.j2
+++ b/templates/borg-backup.sh.j2
@@ -15,7 +15,11 @@ if [ "$1" = "info" ]
   then
     if [ -z "$2" ]; then printf "run $0 with list and use the backup-tag to request information\n"; exit 1; fi
 {% for b in borgbackup_servers %}
-    REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% if b.type == 'hetzner' %}
+    REPOSITORY=ssh://{{ b.user }}@{{ b.fqdn }}:23/./{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% else %}
+    REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% endif %}
     /usr/local/bin/borg info {{ b.options }} $REPOSITORY::$2
 {% endfor %}
     exit 0
@@ -27,7 +31,11 @@ if [ "$1" = "mount" ]
     if [ -z "$3" ]; then printf "Select the backup to mount\n"; exit 1; fi
     if [ -z "$4" ]; then printf "Select the path to mount the backup on\n"; exit 1; fi
 {% for b in borgbackup_servers %}
-    REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% if b.type == 'hetzner' %}
+    REPOSITORY=ssh://{{ b.user }}@{{ b.fqdn }}:23/./{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% else %}
+    REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% endif %}
     /usr/local/bin/borg mount {{ b.options }} $REPOSITORY::$3 $4
     if [ "$?" = "0" ]; then printf "Backup mounted on $4, do not forget to unmount!\n"; fi
     exit 0
@@ -37,7 +45,11 @@ fi
 if [ "$1" = "list" ]
   then
 {% for b in borgbackup_servers %}
-    REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% if b.type == 'hetzner' %}
+    REPOSITORY=ssh://{{ b.user }}@{{ b.fqdn }}:23/./{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% else %}
+    REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% endif %}
     printf "Archives on {{ b.fqdn }} :\n"
     /usr/local/bin/borg list {{ b.options }} -v $REPOSITORY
 {% endfor %}
@@ -47,7 +59,11 @@ fi
 if [ "$1" = "init" ]
   then
 {% for b in borgbackup_servers %}
-    REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% if b.type == 'hetzner' %}
+    REPOSITORY=ssh://{{ b.user }}@{{ b.fqdn }}:23/./{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% else %}
+    REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% endif %}
     /usr/local/bin/borg init --encryption={{ borgbackup_encryption_mode }}{% if borgbackup_appendonly_repoconfig %} --append-only{% endif %} {{ b.options }} $REPOSITORY
 {% endfor %}
     exit 0
@@ -64,7 +80,11 @@ if [ "$1" = "backup" ]
 
 {% for b in borgbackup_servers %}
     printf "Backing up to {{ b.fqdn }} :\n"
-    REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% if b.type == 'hetzner' %}
+    REPOSITORY=ssh://{{ b.user }}@{{ b.fqdn }}:23/./{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% else %}
+    REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
+{% endif %}
     
     /usr/local/bin/borg create --progress --compression {{ borgbackup_compression }} --stats {{ b.options }} $REPOSITORY::$date {% for dir in borgbackup_include %}{{ dir }} {% endfor %}{% if automysql.stat.isdir is defined and automysql.stat.isdir == True %}/var/lib/automysqlbackup{% endif %} {% for dir in borgbackup_exclude %} --exclude '{{ dir }}'{% endfor %}
 

--- a/templates/prune.sh.j2
+++ b/templates/prune.sh.j2
@@ -10,7 +10,7 @@
     {% for b in hostvars[h].borgbackup_servers %}
       {% if hostvars[h].borgbackup_management_station is defined and inventory_hostname == hostvars[h].borgbackup_management_station %}
       export BORG_PASSPHRASE={{ hostvars[h].borgbackup_passphrase }}
-      REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ h }}
+      REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ h }}
       /usr/local/bin/borg prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}
 
       {% endif %}

--- a/templates/prune.sh.j2
+++ b/templates/prune.sh.j2
@@ -8,7 +8,7 @@
   {% if hostvars[h].borgbackup_required | default(True) %}
       # Host: {{ h }}
     {% for b in hostvars[h].borgbackup_servers %}
-      {% if hostvars[h].borgbackup_managementstation is defined and inventory_hostname == hostvars[h].borgbackup_managementstation %}
+      {% if hostvars[h].borgbackup_management_station is defined and inventory_hostname == hostvars[h].borgbackup_management_station %}
       export BORG_PASSPHRASE={{ hostvars[h].borgbackup_passphrase }}
       REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ h }}
       /usr/local/bin/borg prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}

--- a/templates/prune.sh.j2
+++ b/templates/prune.sh.j2
@@ -14,7 +14,11 @@
     {% if hostvars[h].borgbackup_management_station is defined and inventory_hostname == hostvars[h].borgbackup_management_station %}
     {% for b in hostvars[h].borgbackup_servers %}
     # {{ b.fqdn }}
-      REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ h }}
+{% if b.type == 'hetzner' %}
+      REPOSITORY=ssh://{{ b.user }}@{{ b.fqdn }}:23/./{{ b.home }}{{ b.pool }}/{{ h }}
+{% else %}
+      REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ h }}
+{% endif %}
       /usr/local/bin/borg prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}
 
   {% endfor %}

--- a/templates/prune.sh.j2
+++ b/templates/prune.sh.j2
@@ -1,3 +1,4 @@
+#jinja2:lstrip_blocks: True
 #!/bin/bash
 
 # This script is intended to run on a trusted management station to purge borg repo's in
@@ -5,15 +6,18 @@
 # Don't put it on the backup server, it contains all borg secrets!
 
 {% for h in groups['all'] %}
-  {% if hostvars[h].borgbackup_required | default(True) %}
-      # Host: {{ h }}
+  {% if hostvars[h].borgbackup_required | default(True) -%}
+  # Host: {{ h }}
+
+    export BORG_PASSPHRASE={{ hostvars[h].borgbackup_passphrase }}
+
+    {% if hostvars[h].borgbackup_management_station is defined and inventory_hostname == hostvars[h].borgbackup_management_station %}
     {% for b in hostvars[h].borgbackup_servers %}
-      {% if hostvars[h].borgbackup_management_station is defined and inventory_hostname == hostvars[h].borgbackup_management_station %}
-      export BORG_PASSPHRASE={{ hostvars[h].borgbackup_passphrase }}
+    # {{ b.fqdn }}
       REPOSITORY={% if b.type == 'hetzner' %}ssh://{% endif %}{{ b.user }}@{{ b.fqdn }}:{% if b.type == 'hetzner' %}23/./{% endif %}{{ b.home }}{{ b.pool }}/{{ h }}
       /usr/local/bin/borg prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}
 
-      {% endif %}
-    {% endfor %}
+  {% endfor %}
+  {% endif %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
* corrected variable name
* adding support for hetzner-type backups in prune.sh
* cleaner output for prune.sh

Original:
`                    # Host: client1
                export BORG_PASSPHRASE=iechooxei7yooY
      REPOSITORY=borgbackup@normalbackupserver:/var/backup/repos/client1
      /usr/local/bin/borg prune -v $REPOSITORY  -H 12 -d 7 -w 4 -m 6 -y 3

                      export BORG_PASSPHRASE=iechooxei7yooY
      REPOSITORY=ssh://uxxxxxx@uxxxxxx.your-storagebox.de:23/./repos/client1
      /usr/local/bin/borg prune -v $REPOSITORY  -H 12 -d 7 -w 4 -m 6 -y 3`
New:
`# Host: client1

    export BORG_PASSPHRASE=iechooxei7yooY

    # normalbackupserver
      REPOSITORY=borgbackup@normalbackupserver:/var/backup/repos/client1
      /usr/local/bin/borg prune -v $REPOSITORY  -H 12 -d 7 -w 4 -m 6 -y 3

    # uxxxxxx.your-storagebox.de
      REPOSITORY=ssh://uxxxxxx@uxxxxxx.your-storagebox.de:23/./repos/client1
      /usr/local/bin/borg prune -v $REPOSITORY  -H 12 -d 7 -w 4 -m 6 -y 3`