### PR TITLE
Feature/extend log

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ borgbackup_servers:
     home: /backup/
     pool: repos
     options: ""
+    alias: fiaasco
   - fqdn: yourhost.rsync.net
     user: userid
     type: rsync.net
@@ -37,6 +38,7 @@ borgbackup_servers:
     home: ""
     pool: repos
     options: ""
+    alias: hetznerde
 
 
 borgbackup_retention:

--- a/templates/borg-backup.sh.j2
+++ b/templates/borg-backup.sh.j2
@@ -88,7 +88,7 @@ if [ "$1" = "backup" ]
     
     /usr/local/bin/borg create --progress --compression {{ borgbackup_compression }} --stats {{ b.options }} $REPOSITORY::$date {% for dir in borgbackup_include %}{{ dir }} {% endfor %}{% if automysql.stat.isdir is defined and automysql.stat.isdir == True %}/var/lib/automysqlbackup{% endif %} {% for dir in borgbackup_exclude %} --exclude '{{ dir }}'{% endfor %}
 
-    if [ "$?" -eq "0" ]; then printf "Backup succeeded on $date to {{ b.fqdn }}\n" >> /var/log/borg-backup.log; fi
+    if [ "$?" -eq "0" ]; then printf "Backup succeeded on $date to {{ b.fqdn }}\n" >> /var/log/borg-backup-{{ b.alias|default(b.fqdn) }}.log; fi
 
   {% if not borgbackup_appendonly %}
     # prune old backups
@@ -102,4 +102,3 @@ if [ "$1" = "backup" ]
 {% endfor %}
 
 fi
-


### PR DESCRIPTION
Logging to a single file (/var/log/borg-backup.log) obfuscates failing backups.

`Backup succeeded on 20181109-0143 to example.backup.org
Backup succeeded on 20181110-0143 to example.backup.org
Backup succeeded on 20181111-0143 to example.backup.org
Backup succeeded on 20181112-0247 to example.backup.org
Backup succeeded on 20181112-0247 to hetzner.your-storagebox.de
Backup succeeded on 20181113-0247 to example.backup.org
Backup succeeded on 20181113-0247 to hetzner.your-storagebox.de
Backup succeeded on 20181114-0247 to example.backup.org `

As you can see, failing backups did not make it to the borg-backup.log.

New proposal is logging to separate files:

`/var/log/borg-backup-hetzner.log
/var/log/borg-backup-example.log`

Allowing monitoring to get the correct status for all backup-targets.