### PR TITLE
Hotfix/user creation

### DIFF
--- a/tasks/borg-server.yml
+++ b/tasks/borg-server.yml
@@ -7,6 +7,7 @@
     createhome: "yes"
   delegate_to: "{{ item.fqdn }}"
   with_items: "{{ borgbackup_servers }}"
+  run_once: true
   when: item.type == 'normal'
 
 - name: server | create directories


### PR DESCRIPTION
When a set of clients is configured at once to a new backup-server, sometimes a race-condition is met during the multiple delegate_to for creating the backup-user on the target backup-machine.

During the useradd, the previous useradd is still running or hasn't finished completely and the new 'useradd' seems to run into trouble.

Fixing by using 'run_once' in this task.

Before:

>     TASK [borgbackup : server | create user] ***************************************
    changed: [multiple-sds -> multiple-sds] => (item={u'user': u'borgdj', u'home': u'/var/backup-jail/', u'type': u'normal', u'fqdn': u'multiple-sds', u'pool': u'repos', u'options': u''})
    changed: [multiple-sub -> multiple-sds] => (item={u'user': u'borgdj', u'home': u'/var/backup-jail/', u'type': u'normal', u'fqdn': u'multiple-sds', u'pool': u'repos', u'options': u''})
    failed: [multiple-sub -> multiple-sub] (item={u'user': u'borgux', u'home': u'/var/backup-jail/', u'type': u'normal', u'fqdn': u'multiple-sub', u'pool': u'repos', u'options': u''}) => {"changed": false, "item": {"fqdn": "multiple-sub", "home": "/var/backup-jail/", "options": "", "pool": "repos", "type": "normal", "user": "borgux"}, "msg": "useradd: user 'borgux' already exists\n", "name": "borgux", "rc": 9}
    changed: [multiple-sds -> multiple-sub] => (item={u'user': u'borgux', u'home': u'/var/backup-jail/', u'type': u'normal', u'fqdn': u'multiple-sub', u'pool': u'repos', u'options': u''})

After (with run_once):
>     TASK [borgbackup : server | create user] ***************************************
    changed: [multiple-sub -> multiple-sds] => (item={u'user': u'borgdj', u'home': u'/var/backup-jail/', u'type': u'normal', u'fqdn': u'multiple-sds', u'pool': u'repos', u'options': u''})
    changed: [multiple-sub -> multiple-sub] => (item={u'user': u'borgux', u'home': u'/var/backup/', u'type': u'normal', u'fqdn': u'multiple-sub', u'pool': u'repos', u'options': u''})


The end result is the same, the user is created. I only started noticing this problem when using Ubuntu Bionic as a backupserver, it seems to be fine when using Debian Jessie..