### PR TITLE
Allow users to install borgbackup package instead of downloading binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ Be aware of the limitations of append-only mode: [pruned backups appear to be re
 
 *Make sure to check the configured defaults for this role, which contains the list of default locations being backed up in backup\_include.* Override this in your inventory where required.
 
-## Installing Borg from EPEL Package
+## Installing Borg from Package
 Borg can be installed from an EPEL package by setting the variable:
 ```
 borgbackup_install_from_pkg: true
 ```
 
-The EPEL repo must be present for this to succeed. To install the EPEL repo using the
+On CentOS the EPEL repo must be present for this to succeed. To install the EPEL repo using the
 [`geerlingguy.repo-epel`](https://galaxy.ansible.com/geerlingguy/repo-epel) role, set:
 ```
 borgbackup_install_epel: true

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ Be aware of the limitations of append-only mode: [pruned backups appear to be re
 
 *Make sure to check the configured defaults for this role, which contains the list of default locations being backed up in backup\_include.* Override this in your inventory where required.
 
+## Installing Borg from EPEL Package
+Borg can be installed from an EPEL package by setting the variable:
+```
+borgbackup_install_from_pkg: true
+```
+
+The EPEL repo must be present for this to succeed. To install the EPEL repo using the
+[`geerlingguy.repo-epel`](https://galaxy.ansible.com/geerlingguy/repo-epel) role, set:
+```
+borgbackup_install_epel: true
+```
+
 ## Usage
 
 Configure Borg on the server and on a client:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,9 +24,12 @@ borgbackup_download_url: "https://github.com/borgbackup/borg/releases/download/{
 # description: name of binary to execute in scripts for borg backup
 # type: string
 borgbackup_binary: "borg"
-# description: whether to install borg backup using the package manager
+# description: whether to install borg backup from package
 # type: bool
 borgbackup_install_from_pkg: false
+# description: whether to install the EPEL repository (EPEL required to install from package)
+# type: bool
+borgbackup_install_epel: false
 # description: name of package to install when borgbackup_install_from_pkg is true
 # type: string
 borgbackup_package: "borgbackup"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,16 @@ borgbackup_checksum: "sha256:6338d67aad4b5cd327b25ea363e30f0ed4abc425ce2d6a597c7
 # type: string
 borgbackup_download_url: "https://github.com/borgbackup/borg/releases/download/{{ borgbackup_version }}/borg-linux64"
 
+# description: name of binary to execute in scripts for borg backup
+# type: string
+borgbackup_binary: "borg"
+# description: whether to install borg backup using the package manager
+# type: bool
+borgbackup_install_from_pkg: false
+# description: name of package to install when borgbackup_install_from_pkg is true
+# type: string
+borgbackup_package: "borgbackup"
+
 # description: borg compression to use
 # choices:
 # type: string

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ borgbackup_binary: "borg"
 # description: whether to install borg backup from package
 # type: bool
 borgbackup_install_from_pkg: false
-# description: whether to install the EPEL repository (EPEL required to install from package)
+# description: whether to install the EPEL repository (EPEL required to install from package on CentOS)
 # type: bool
 borgbackup_install_epel: false
 # description: name of package to install when borgbackup_install_from_pkg is true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,7 @@
 ---
+dependencies:
+  - geerlingguy.repo-epel
+
 galaxy_info:
   author: Luc Stroobant and Dieter Verhelst
   description: Install Borg backup server and client (with rsync.net server support)

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: geerlingguy.repo-epel
+  version: 1.2.3

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: geerlingguy.repo-epel
-  version: 1.2.3
+  version: 1.2.4

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,6 @@
 ---
 - src: geerlingguy.repo-epel
   version: 1.2.4
+  when: >
+  ansible_os_family == 'Redhat'
+  and borgbackup_install_epel

--- a/tasks/borg-client.yml
+++ b/tasks/borg-client.yml
@@ -18,6 +18,7 @@
     state: "present"
     line: 'export BORG_PASSPHRASE="{{ borgbackup_passphrase }}"'
     create: true
+  no_log: true
 
 - name: client | disable strict key checking for backup servers
   blockinfile:

--- a/tasks/borg-client.yml
+++ b/tasks/borg-client.yml
@@ -8,7 +8,7 @@
     ssh_key_type: rsa
 
 - name: client | fetch ssh-key
-  shell: "cat {{ borgbackup_ssh_key }}.pub"
+  command: "cat {{ borgbackup_ssh_key }}.pub"
   register: sshkey
   changed_when: false
 
@@ -37,7 +37,7 @@
   authorized_key:
     user: "{{ item.user }}"
     key: "{{ sshkey.stdout }}"
-    key_options: 'command="cd {{ item.home }}{{ item.pool }}/{{ inventory_hostname }};borg serve {% if borgbackup_appendonly %}--append-only {% endif %}--restrict-to-path {{ item.home }}/{{ item.pool }}/{{ inventory_hostname }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc'
+    key_options: 'command="cd {{ item.home }}{{ item.pool }}/{{ inventory_hostname }};borg serve {% if borgbackup_appendonly %}--append-only {% endif %}--restrict-to-path {{ item.home }}/{{ item.pool }}/{{ inventory_hostname }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc' # noqa 204 (Line has to be this long for valid formatting)
   delegate_to: "{{ item.fqdn }}"
   when: item.type == 'normal'
   with_items: "{{ borgbackup_servers }}"
@@ -55,7 +55,7 @@
   authorized_key:
     user: "{{ ansible_user_id }}"
     key: "{{ sshkey.stdout }}"
-    key_options: 'command="cd {{ item.pool }}/{{ inventory_hostname }};/usr/local/bin/borg1 serve {% if borgbackup_appendonly %}--append-only {% endif %} --restrict-to-path {{ item.pool }}/{{ inventory_hostname }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc'
+    key_options: 'command="cd {{ item.pool }}/{{ inventory_hostname }};/usr/local/bin/borg1 serve {% if borgbackup_appendonly %}--append-only {% endif %} --restrict-to-path {{ item.pool }}/{{ inventory_hostname }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc' # noqa 204 (Line has to be this long for valid formatting)
     path: "/tmp/authkeys-{{ item.type }}-{{ item.fqdn }}-authkeys"
     manage_dir: false
   delegate_to: localhost
@@ -94,7 +94,8 @@
     mode: "0744"
 
 - name: client | create backup-directory on backup server
-  shell: /usr/local/bin/borg-backup init
+  command: /usr/local/bin/borg-backup init
+  become: true
   become_user: "{{ borgbackup_client_user }}"
   register: backup_init
   changed_when: "'Remember your passphrase' in backup_init.stderr"
@@ -117,4 +118,4 @@
     state: "present"
     backrefs: true
     create: false
-  when: automysql.stat.isdir is defined and automysql.stat.isdir == True
+  when: automysql.stat.isdir is defined and automysql.stat.isdir

--- a/tasks/borg-server.yml
+++ b/tasks/borg-server.yml
@@ -21,7 +21,7 @@
 
 - name: server | create directories
   file:
-    path: "{{ item.home}}{{ item.pool }}"
+    path: "{{ item.home }}{{ item.pool }}"
     state: "directory"
     owner: "{{ item.user }}"
     group: "{{ item.user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,12 @@
 ---
-- name: install borg backup
+# Use full path when using borg binary downloaded from web
+- name: install | set borg binary path
+  set_fact:
+    borgbackup_binary: "/usr/local/bin/borg"
+  tags: borginstall
+  when: not borgbackup_install_from_pkg
+
+- name: install | install borg binary from web
   get_url:
     dest: "/usr/local/bin/borg"
     checksum: "{{ borgbackup_checksum }}"
@@ -8,3 +15,11 @@
     mode: "0755"
     url: "{{ borgbackup_download_url }}"
   tags: borginstall
+  when: not borgbackup_install_from_pkg
+
+- name: install | install borgbackup package
+  package:
+    name: "{{ borgbackup_package }}"
+    state: present
+  tags: borginstall
+  when: borgbackup_install_from_pkg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- include_tasks: setup-RedHat.yml
+  when: borgbackup_install_from_pkg and ansible_os_family == 'RedHat'
+
 # Due to inverse logic behaviour when searching for an item in an undefined list.
 - name: setting facts
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - include_tasks: install.yml
   when: >
-    borgbackup_required == True or
+    borgbackup_required or
     inventory_hostname in borgbackup_servers_group
 
 - include_tasks: borg-server.yml
@@ -18,7 +18,7 @@
 
 - include_tasks: borg-client.yml
   when: >
-    borgbackup_required == True and
+    borgbackup_required and
     inventory_hostname not in borgbackup_servers_group
 
 - include_tasks: management.yml

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,0 +1,4 @@
+---
+- name: "Install EPEL repo"
+  include_role:
+    name: geerlingguy.repo-epel

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -2,3 +2,4 @@
 - name: "Install EPEL repo"
   include_role:
     name: geerlingguy.repo-epel
+  when: borgbackup_install_epel

--- a/templates/borg-backup.sh.j2
+++ b/templates/borg-backup.sh.j2
@@ -20,7 +20,7 @@ if [ "$1" = "info" ]
 {% else %}
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
-    /usr/local/bin/borg info {{ b.options }} $REPOSITORY::$2
+    {{ borgbackup_binary }} info {{ b.options }} $REPOSITORY::$2
 {% endfor %}
     exit 0
 fi
@@ -36,7 +36,7 @@ if [ "$1" = "mount" ]
 {% else %}
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
-    /usr/local/bin/borg mount {{ b.options }} $REPOSITORY::$3 $4
+    {{ borgbackup_binary }} mount {{ b.options }} $REPOSITORY::$3 $4
     if [ "$?" = "0" ]; then printf "Backup mounted on $4, do not forget to unmount!\n"; fi
     exit 0
 {% endfor %}
@@ -51,7 +51,7 @@ if [ "$1" = "list" ]
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
     printf "Archives on {{ b.fqdn }} :\n"
-    /usr/local/bin/borg list {{ b.options }} -v $REPOSITORY
+    {{ borgbackup_binary }} list {{ b.options }} -v $REPOSITORY
 {% endfor %}
     exit 0
 fi
@@ -64,7 +64,7 @@ if [ "$1" = "init" ]
 {% else %}
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
-    /usr/local/bin/borg init --encryption={{ borgbackup_encryption_mode }}{% if borgbackup_appendonly_repoconfig %} --append-only{% endif %} {{ b.options }} $REPOSITORY
+    {{ borgbackup_binary }} init --encryption={{ borgbackup_encryption_mode }}{% if borgbackup_appendonly_repoconfig %} --append-only{% endif %} {{ b.options }} $REPOSITORY
 {% endfor %}
     exit 0
 fi
@@ -86,13 +86,13 @@ if [ "$1" = "backup" ]
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
     
-    /usr/local/bin/borg create --progress --compression {{ borgbackup_compression }} --stats {{ b.options }} $REPOSITORY::$date {% for dir in borgbackup_include %}{{ dir }} {% endfor %}{% if automysql.stat.isdir is defined and automysql.stat.isdir == True %}/var/lib/automysqlbackup{% endif %} {% for dir in borgbackup_exclude %} --exclude '{{ dir }}'{% endfor %}
+    {{ borgbackup_binary }} create --progress --compression {{ borgbackup_compression }} --stats {{ b.options }} $REPOSITORY::$date {% for dir in borgbackup_include %}{{ dir }} {% endfor %}{% if automysql.stat.isdir is defined and automysql.stat.isdir == True %}/var/lib/automysqlbackup{% endif %} {% for dir in borgbackup_exclude %} --exclude '{{ dir }}'{% endfor %}
 
     if [ "$?" -eq "0" ]; then printf "Backup succeeded on $date to {{ b.fqdn }}\n" >> /var/log/borg-backup.log; fi
 
   {% if not borgbackup_appendonly %}
     # prune old backups
-    /usr/local/bin/borg prune {{ b.options }} -v $REPOSITORY -H {{ borgbackup_retention.hourly }} -d {{ borgbackup_retention.daily }} -w {{ borgbackup_retention.weekly }} -m {{ borgbackup_retention.monthly }} -y {{ borgbackup_retention.yearly }}
+    {{ borgbackup_binary }} prune {{ b.options }} -v $REPOSITORY -H {{ borgbackup_retention.hourly }} -d {{ borgbackup_retention.daily }} -w {{ borgbackup_retention.weekly }} -m {{ borgbackup_retention.monthly }} -y {{ borgbackup_retention.yearly }}
   {% endif %}
 {% endfor %}
 

--- a/templates/prune.sh.j2
+++ b/templates/prune.sh.j2
@@ -19,7 +19,7 @@
 {% else %}
       REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ h }}
 {% endif %}
-      /usr/local/bin/borg prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}
+      {{ borgbackup_binary }} prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}
 
   {% endfor %}
   {% endif %}


### PR DESCRIPTION
This replaces PR https://github.com/fiaasco/borgbackup/pull/18. Original PR description:
>I think it would be helpful to have support for installing borg backup from the package manager.

>I've tested this installing from both package and web in a local vagrant environment on CentOS 7, and was able to take a backup successfully both ways.

This offers all of the changes from our fork at https://github.com/tag1consulting/ansible-role-borgbackup that aren't Tag1-specific.

The primary addition here is the ability to install borgbackup from a package (via EPEL), but this also includes a couple ansible-lint fixes.

I tested #18 back when I made those changes, but I don't have the cycles to test this again, so hopefully someone else can take that on.

Happy to see that this repo is active again. :)