### PR TITLE
Fix requiring geerlingguy.epel role only when necessary

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
-  - geerlingguy.repo-epel
+  - name: geerlingguy.repo-epel
+    when: ansible_os_family == 'RedHat' and borgbackup_install_epel
 
 galaxy_info:
   author: Luc Stroobant and Dieter Verhelst

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,3 @@
 ---
 - src: geerlingguy.repo-epel
   version: 1.2.4
-  when: >
-  ansible_os_family == 'Redhat'
-  and borgbackup_install_epel


### PR DESCRIPTION
Thanks @noplanman for pointing out the requirement was wrong in https://github.com/fiaasco/borgbackup/pull/25#issuecomment-611190431.

My bad, this is what I get for trying to slip quick changes into my day. ;)

Haven't tested it because I'm still trash.