### PR TITLE
Fix tests with CentOS and allow forked builds to test correctly with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,28 @@
 ---
-sudo: required
-
 language: python
+services: docker
 
-services:
-  - docker
+env:
+  - SCENARIO: default
+  - SCENARIO: centos
+  - SCENARIO: ubuntu
+  - SCENARIO: clients
+  - SCENARIO: lamp
+  - SCENARIO: multiple
 
-before_install:
-  - sudo apt-get -qq update
+#  - SCENARIO: lamp
+#  - SCENARIO: extra_opts
+#  - SCENARIO: multiple
 
 install:
   - pip install -r requirements.txt
 
-env:
-  - SCENARIO=default
-  - SCENARIO=centos
-  - SCENARIO=ubuntu
-  - SCENARIO=clients
-  - SCENARIO=lamp
-  - SCENARIO=multiple
+before_script:
+  # Rename current directory to allow forked tests to work.
+  - mv ../$(basename $PWD) ../borgbackup
 
-#  - SCENARIO=lamp
-#  - SCENARIO=extra_opts
-#  - SCENARIO=multiple
+script:
+  - molecule test --scenario-name $SCENARIO
 
-script: "molecule test --scenario-name $SCENARIO"
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 before_script:
   # Rename current directory to allow forked tests to work.
-  - mv ../$(basename $PWD) ../borgbackup
+  - mv ../$(basename $PWD) ../borgbackup 2>/dev/null || true
 
 script:
   - molecule test --scenario-name $SCENARIO

--- a/molecule/generic_files/Dockerfile.j2
+++ b/molecule/generic_files/Dockerfile.j2
@@ -8,8 +8,8 @@ FROM {{ item.image }}
 {% endif %}
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y apt-utils python sudo bash ca-certificates systemd dbus lsb-release && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-devel python3-dnf bash redhat-lsb-core && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash redhat-lsb-core && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf install -y redhat-lsb-core && dnf install -y python3 sudo python3-devel python3-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y redhat-lsb-core && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml systemd lsb-release dbus-1 systemd-sysvinit hostname && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/generic_files/playbook.yml
+++ b/molecule/generic_files/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: borgbackup
+    - ../../..

--- a/molecule/generic_files/playbook.yml
+++ b/molecule/generic_files/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - ../../..
+    - role: borgbackup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,8 +9,8 @@
     - always
 
 - name: include installation tasks
-  include_tasks:
-    file: install.yml
+  include_tasks: install.yml
+  args:
     apply:
       tags:
         - borginstall


### PR DESCRIPTION
- ~Sets the path to the role relatively, thus not requiring the root folder to be named `borgbackup` (@dverhelst this was the problem I had mentioned in https://github.com/fiaasco/borgbackup/pull/33#issuecomment-612212570)~
- Fix the tag applying which ansible lint doesn't seem to like. Was getting the following error before with the other syntax:
```
--> Executing Ansible Lint on /Users/noplanman/Projects/Ansible/ansible-role-borgbackup/molecule/default/playbook.yml...
WARNING: Couldn't open /Users/noplanman/Projects/Ansible/ansible-role-borgbackup/tasks/{'file': - No such file or directory
```
- Allow forked builds with Travis CI by renaming the build folder to a static `borgbackup`
- Let Ansible Galaxy know about the build status