### PR TITLE
Fix Hetzner SSH config and borg path

### DIFF
--- a/tasks/borg-client.yml
+++ b/tasks/borg-client.yml
@@ -67,7 +67,7 @@
       authorized_key:
         user: "{{ ansible_user_id }}"
         key: "{{ sshkey.stdout }}"
-        key_options: 'command="cd {{ item.pool }}/{{ inventory_hostname }};/usr/local/bin/borg1 serve {% if borgbackup_appendonly %}--append-only {% endif %}--restrict-to-path {{ item.pool }}/{{ inventory_hostname }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc'  # noqa 204 (Line has to be this long for valid formatting)
+        key_options: 'command="borg-1.2 serve {% if borgbackup_appendonly %}--append-only {% endif %}--restrict-to-path {{ item.pool }}/{{ inventory_hostname }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc'  # noqa 204 (Line has to be this long for valid formatting)
         path: "/tmp/authkeys-{{ item.type }}-{{ item.fqdn }}-authkeys"
         manage_dir: false
       delegate_to: localhost


### PR DESCRIPTION
For quite some time now Hetzner Storage Box backups had stopped working with the existing SSH config.

The output when performing the backup would simply be:
```
Got unexpected RPC data format from server:
Command not found. Use 'help' to get a list of available commands.
```

This is because they seem to have tightened up the allowed commands on the backend, so the `cd` command fails.
As far as I can tell, it isn't necessary to change directory first, as the `--restrict-to-path` should take care of this.

Also, the executable path no longer works with an absolute path, and the executable name has changed format too...

With all that in mind, using "borg-1.2" works for both Hetzner and rsync, so this works perfectly for me and my backups all work with this new config in place.