### PR TITLE
Don't exit on backup error or warning

### DIFF
--- a/templates/borg-backup.sh.j2
+++ b/templates/borg-backup.sh.j2
@@ -76,8 +76,6 @@ if [ "$1" = "init" ]; then
 fi
 
 if [ "$1" = "backup" ]; then
-    set -e
-
     DATE=$(date +%Y%m%d-%H%M)
     EXIT_CODE=0
 


### PR DESCRIPTION
When the backup exits with a warning or error, the `set -e` makes the script exit immediately.
This means that no post commands are called at all, which may be necessary regardless, like for health checks.

Instead, if the exit code is vital for any post commands, it should be added to explicitly to them.